### PR TITLE
Correction to the free selective map definition

### DIFF
--- a/core/src/main/scala/cats/free/FreeRigidSelective.scala
+++ b/core/src/main/scala/cats/free/FreeRigidSelective.scala
@@ -46,22 +46,23 @@ object FreeRigidSelective {
   }
 
   implicit def selective[F[_]: Functor]: Selective[FreeRigidSelective[F, ?]] = new Selective[FreeRigidSelective[F, ?]] {
+
     override def applicative: Applicative[FreeRigidSelective[F, ?]] = new Applicative[FreeRigidSelective[F, ?]] {
       override def map[A, B](fa: FreeRigidSelective[F, A])(f: A => B): FreeRigidSelective[F, B] =
         fa match {
           case x: Pure[F, A] => Pure(f(x.run))
-          case w: Select.Aux[F, A, B] =>
+          case w: Select.Aux[F, _, A] =>
             new Select[F, B] {
-              type Source = B
+              type Source = w.Source
               /**
                 *There is a bit of primitive recursion here that cannot be eliminated.
                 * Since all free selective expressions are finite, this is guaranteed to terminate,
                 * however it is not tail recursive, so your stack is your own.
                 **/
-              val feab: FreeRigidSelective[F, Either[Source, B]] =
-                map(w.feab)((e: Either[w.Source, B]) => e.leftMap(f))
+              val feab: FreeRigidSelective[F, Either[w.Source, B]] =
+                map(w.feab)(e => e.map(f))
 
-              val fab: F[Source => B] = Functor[F].map(w.fab)(f andThen _)
+              val fab: F[Source => B] = Functor[F].map(w.fab)(_ andThen f)
             }
         }
 

--- a/core/src/main/scala/cats/free/FreeRigidSelective.scala
+++ b/core/src/main/scala/cats/free/FreeRigidSelective.scala
@@ -51,7 +51,7 @@ object FreeRigidSelective {
       override def map[A, B](fa: FreeRigidSelective[F, A])(f: A => B): FreeRigidSelective[F, B] =
         fa match {
           case x: Pure[F, A] => Pure(f(x.run))
-          case w: Select.Aux[F, _, A] =>
+          case w: Select[F, A] =>
             new Select[F, B] {
               type Source = w.Source
               /**

--- a/tests/src/test/scala/cats/tests/FreeRigidSelectiveSuite.scala
+++ b/tests/src/test/scala/cats/tests/FreeRigidSelectiveSuite.scala
@@ -1,0 +1,92 @@
+package cats.tests
+
+import cats._
+import cats.instances.all._
+import cats.free.FreeRigidSelective
+import scala.io.StdIn
+import cats.data.Writer
+import cats.syntax.`package`.nonEmptyTraverse
+
+class FreeRigidSelectiveSuite extends CatsSuite {
+
+  import FreeRigidSelectiveSuite._
+  import FreeRigidSelectiveSuite.interpreters._
+
+  val S = implicitly[Selective[Teletype]]
+  val A = S.applicative
+
+  test("readLine should execute correctly") {
+    val (written, result) = FreeRigidSelective.runSelect(mock("hello"))(readLine).run
+
+    result shouldBe ("hello")
+    written shouldBe empty
+  }
+
+  test("print should execute correctly") {
+    val (written, result) = FreeRigidSelective.runSelect(mock())(print("Hello World")).run
+
+    result shouldBe ()
+    written shouldBe List("Hello World")
+  }
+
+  test("pingPong should print \"pong\" when pinged") {
+    val pingPong = S.whenS(A.fmap(readLine)(_ == "ping"))(print("pong"))
+    val (written, result) = FreeRigidSelective.runSelect(mock("ping"))(pingPong).run
+
+    result shouldBe ()
+    written shouldBe List("pong")
+  }
+
+  test("pingPong should print nothing when not pinged") {
+    val pingPong = S.whenS(A.fmap(readLine)(_ == "ping"))(print("pong"))
+    val (written, result) = FreeRigidSelective.runSelect(mock("not ping"))(pingPong).run
+
+    result shouldBe ()
+    written shouldBe empty
+  }
+
+}
+
+object FreeRigidSelectiveSuite {
+
+  // PingPong example taken from the paper [1]
+  // [1] https://www.staff.ncl.ac.uk/andrey.mokhov/selective-functors.pdf
+  sealed trait TeletypeOp[A]
+  final case class Read[A](parse: String => A) extends TeletypeOp[A]
+  final case class Write[A](output: String, a: A) extends TeletypeOp[A]
+
+  object TeletypeOp {
+    implicit def functor: Functor[TeletypeOp] = new Functor[TeletypeOp] {
+      def map[A, B](fa: TeletypeOp[A])(f: A => B): TeletypeOp[B] = fa match {
+        case Read(parse) => Read(s => f(parse(s)))
+        case Write(s, a) => Write(s, f(a))
+      }
+    }
+  }
+
+  type Teletype[A] = FreeRigidSelective[TeletypeOp, A]
+
+  def read[A](parse: String => A): Teletype[A] =
+    FreeRigidSelective.liftSelect[TeletypeOp, A](Read(parse))
+
+  def write[A](s: String, a: A): Teletype[A] =
+    FreeRigidSelective.liftSelect[TeletypeOp, A](Write(s, a))
+
+  def readLine: Teletype[String] = read[String](identity)
+  def print(s: String): Teletype[Unit] = write[Unit](s, ())
+
+  object interpreters {
+
+    implicit val mockSelective: Selective[MockState] = Selective.fromMonad[MockState]
+
+    type MockState[A] = Writer[List[String], A]
+    def mock(input: String = ""): TeletypeOp ~> MockState = new (TeletypeOp ~> MockState) {
+      def apply[A](fa: TeletypeOp[A]): MockState[A] = fa match {
+        case Read(parse) => Writer(Nil, parse(input))
+        case Write(s, a) => Writer(List(s), a)
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
Hi!

I recently came across the Selective Applicative Functors paper and eventually found myself playing around with the implementation in this repo.  It's been really great to help work through the paper, thank you!

I found I was getting a runtime `ClassCastException` when attempting to construct small free-selective programs that involved `fmap` from `Applicative[FreeRigidSelective]`.  Eg. constructing programs like this:

```
val pingPong = S.whenS(A.fmap(readLine)(_ == "ping"))(print("pong"))
```

Would cause a runtime exception, something like:
```
[info] - pingPong should print "pong" when pinged *** FAILED ***
[info]   java.lang.ClassCastException: scala.runtime.BoxedUnit cannot be cast to java.lang.String
[info]   at cats.syntax.EitherOps$.leftMap$extension(either.scala:144)
[info]   at cats.free.FreeRigidSelective$$anon$2$$anon$3$$anon$4.$anonfun$feab$1(FreeRigidSelective.scala:62)
[info]   at cats.free.FreeRigidSelective$$anon$2$$anon$3.map(FreeRigidSelective.scala:52)
[info]   at cats.free.FreeRigidSelective$$anon$2$$anon$3$$anon$4.<init>(FreeRigidSelective.scala:62)
[info]   at cats.free.FreeRigidSelective$$anon$2$$anon$3.map(FreeRigidSelective.scala:54)
[info]   at cats.free.FreeRigidSelective$$anon$2$$anon$3.map(FreeRigidSelective.scala:49)
[info]   at cats.Functor.fmap(Functor.scala:33)
[info]   at cats.Functor.fmap$(Functor.scala:12)
[info]   at cats.free.FreeRigidSelective$$anon$2$$anon$3.fmap(FreeRigidSelective.scala:49)
[info]   at cats.tests.FreeRigidSelectiveSuite.$anonfun$new$3(FreeRigidSelectiveSuite.scala:36)
```

This pull request includes 2 things:

1. A correction to the `Applicative[FreeRigidSelective]` `map` function, which clears up the runtime exception.

2. A minimal test suite that implements the _PingPong_ example from the paper.  *Without* the correction to `map`, the 2 simple cases (`readLine` and `print`) pass, but the `pingPong` example fails.  *With* the correction, they all pass.
