### PR TITLE
Implement apS function

### DIFF
--- a/core/src/main/scala/cats/Selective.scala
+++ b/core/src/main/scala/cats/Selective.scala
@@ -19,22 +19,6 @@ trait Selective[F[_]] {
     select(lhs)(r)
   }
 
-  /**
-    * apS :: Selective f => f (a -> b) -> f a -> f b
-    * apS f x = select (Left <$> f) ((&) <$> x)
-    *
-    *  (&) :: c -> (c -> d) -> d     -- reverse function application
-    *
-    * Although the type signature of `apS` matches `applicative.ap`, in general,
-    * they are *not* equivalent.  Selective functors that *do* satisfy the
-    * property `applicative.ap === apS` are called *rigid* selectives.
-    */
-  def apS[A, B](fn: F[A => B])(fa: F[A]): F[B] = {
-    val leftFn: F[Either[A => B, B]] = map(fn)(Left(_))
-    val application = map(fa)(a => (g: A => B) => g(a))
-    select(leftFn)(application)
-  }
-
   def ifS[A](x: F[Boolean])(t: F[A])(e: F[A]): F[A] = {
     val condition: F[Either[Unit, Unit]] = map(x)(p => if (p) Left(()) else Right(()))
     val left: F[Unit => A] = map(t)(Function.const)
@@ -70,6 +54,22 @@ trait Selective[F[_]] {
       (a: A, lb: Eval[F[Boolean]]) =>
         lb.map(andS(_)(test(a)))
     })
+
+  /**
+    * apS :: Selective f => f (a -> b) -> f a -> f b
+    * apS f x = select (Left <$> f) ((&) <$> x)
+    *
+    *  (&) :: c -> (c -> d) -> d     -- reverse function application
+    *
+    * Although the type signature of `apS` matches `applicative.ap`, in general,
+    * they are *not* equivalent.  Selective functors that *do* satisfy the
+    * property `applicative.ap === apS` are called *rigid* selectives.
+    */
+  def apS[A, B](fn: F[A => B])(fa: F[A]): F[B] = {
+    val leftFn: F[Either[A => B, B]] = map(fn)(Left(_))
+    val application = map(fa)(a => (g: A => B) => g(a))
+    select(leftFn)(application)
+  }
 
   // TODO more combinators here
 }

--- a/laws/src/main/scala/cats/laws/RigidSelectiveLaws.scala
+++ b/laws/src/main/scala/cats/laws/RigidSelectiveLaws.scala
@@ -13,7 +13,7 @@ trait RigidSelectiveLaws[F[_]] {
 
   /**
     * Selectives that satisfy this criteria are known as rigid selectives.
-    * 
+    *
     * `applicative.ap === apS`
     */
   def rigidSelectiveApply[A, B](x: F[A], fn: F[A => B]): IsEq[F[B]] = {
@@ -23,8 +23,7 @@ trait RigidSelectiveLaws[F[_]] {
   }
 
   /**
-    * A consequence of `applicative.ap === apS` and associativity, so don't strictly
-    * need to test this law, but I'm writing it as a sanity check
+    * A consequence of `applicative.ap === apS` and associativity
     *
     * `x *> (y <*? z) === (x *> y) <*? z
     */

--- a/laws/src/main/scala/cats/laws/RigidSelectiveLaws.scala
+++ b/laws/src/main/scala/cats/laws/RigidSelectiveLaws.scala
@@ -1,0 +1,42 @@
+package cats.laws
+
+import cats.Selective
+import cats.Selective.ops._
+
+/**
+  * A selective functor is _rigid_ if it satisfies `<*> = apS`.
+  *
+  * These laws are a consequence of that assumption
+  */
+trait RigidSelectiveLaws[F[_]] {
+  implicit def F: Selective[F]
+
+  /**
+    * Selectives that satisfy this criteria are known as rigid selectives.
+    * 
+    * `applicative.ap === apS`
+    */
+  def rigidSelectiveApply[A, B](x: F[A], fn: F[A => B]): IsEq[F[B]] = {
+    val lhs = F.apS(fn)(x)
+    val rhs = F.applicative.ap(fn)(x)
+    lhs <-> rhs
+  }
+
+  /**
+    * A consequence of `applicative.ap === apS` and associativity, so don't strictly
+    * need to test this law, but I'm writing it as a sanity check
+    *
+    * `x *> (y <*? z) === (x *> y) <*? z
+    */
+  def rigidSelectiveInterchange[A, B](x: F[A], y: F[Either[A, B]], z: F[A => B]): IsEq[F[B]] = {
+    val lhs = F.applicative.*>(x)(F.select(y)(z))
+    val rhs = F.select(F.applicative.*>(x)(y))(z)
+    lhs <-> rhs
+  }
+
+}
+
+object RigidSelectiveLaws {
+  def apply[F[_]](implicit ev: Selective[F]): RigidSelectiveLaws[F] =
+    new RigidSelectiveLaws[F] { def F: Selective[F] = ev }
+}

--- a/laws/src/main/scala/cats/laws/discipline/RigidSelectiveTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/RigidSelectiveTests.scala
@@ -1,0 +1,41 @@
+package cats
+package laws
+package discipline
+
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
+import org.scalacheck.Prop._
+import org.scalacheck.{Arbitrary, Cogen}
+import org.typelevel.discipline.Laws
+
+trait RigidSelectiveTests[F[_]] extends Laws {
+  def laws: RigidSelectiveLaws[F]
+
+  // TODO - probably don't need all these implicit args.  Tidy up
+  def selective[A: Arbitrary, B: Arbitrary, C: Arbitrary](
+    implicit
+    ArbFA: Arbitrary[F[A]],
+    ArbFEitherA: Arbitrary[F[Either[A, A]]],
+    ArbFEitherAB: Arbitrary[F[Either[A, B]]],
+    ArbFEitherCAtoB: Arbitrary[F[Either[C, A => B]]],
+    ArbFAtoB: Arbitrary[F[A => B]],
+    ArbFCtoAtoB: Arbitrary[F[C => A => B]],
+    EqFA: Eq[F[A]],
+    EqFB: Eq[F[B]]
+  ): RuleSet =
+    new DefaultRuleSet(
+      name = "rigid selective",
+      parent = None,
+      "rigid selective apply" -> forAll(laws.rigidSelectiveApply[A, B] _),
+      "rigid selective interchange" -> forAll(laws.rigidSelectiveInterchange[A, B] _)
+    )
+}
+
+object RigidSelectiveTests {
+
+  def apply[F[_]: Selective]: RigidSelectiveTests[F] =
+    new RigidSelectiveTests[F] { def laws: RigidSelectiveLaws[F] = RigidSelectiveLaws[F] }
+
+  def monad[F[_]: Monad]: RigidSelectiveTests[F] =
+    new RigidSelectiveTests[F] { def laws: RigidSelectiveLaws[F] = RigidSelectiveLaws[F](Selective.fromMonad) }
+
+}

--- a/laws/src/main/scala/cats/laws/discipline/RigidSelectiveTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/RigidSelectiveTests.scala
@@ -2,24 +2,18 @@ package cats
 package laws
 package discipline
 
-import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import org.scalacheck.Prop._
-import org.scalacheck.{Arbitrary, Cogen}
+import org.scalacheck.Arbitrary
 import org.typelevel.discipline.Laws
 
 trait RigidSelectiveTests[F[_]] extends Laws {
   def laws: RigidSelectiveLaws[F]
 
-  // TODO - probably don't need all these implicit args.  Tidy up
-  def selective[A: Arbitrary, B: Arbitrary, C: Arbitrary](
+  def selective[A: Arbitrary, B: Arbitrary](
     implicit
     ArbFA: Arbitrary[F[A]],
-    ArbFEitherA: Arbitrary[F[Either[A, A]]],
     ArbFEitherAB: Arbitrary[F[Either[A, B]]],
-    ArbFEitherCAtoB: Arbitrary[F[Either[C, A => B]]],
     ArbFAtoB: Arbitrary[F[A => B]],
-    ArbFCtoAtoB: Arbitrary[F[C => A => B]],
-    EqFA: Eq[F[A]],
     EqFB: Eq[F[B]]
   ): RuleSet =
     new DefaultRuleSet(

--- a/tests/src/test/scala/cats/tests/EvalSuite.scala
+++ b/tests/src/test/scala/cats/tests/EvalSuite.scala
@@ -1,0 +1,17 @@
+package cats.tests
+
+import cats.data._
+import cats.laws.discipline._
+import org.scalacheck.Arbitrary._
+import cats.laws.discipline.arbitrary._
+import cats.Eval
+import cats.Selective
+
+// TODO: abstract this to a general Monad because all monadic selective functors are rigid
+
+class EvalSuite extends CatsSuite {
+
+  implicit val selective = Selective.fromMonad[Eval]
+
+  checkAll("Eval[Int]", RigidSelectiveTests[Eval].selective[Int, Int, Int])
+}

--- a/tests/src/test/scala/cats/tests/EvalSuite.scala
+++ b/tests/src/test/scala/cats/tests/EvalSuite.scala
@@ -13,5 +13,6 @@ class EvalSuite extends CatsSuite {
 
   implicit val selective = Selective.fromMonad[Eval]
 
+  checkAll("Eval[Int]", SelectiveTests[Eval].selective[Int, Int, Int])
   checkAll("Eval[Int]", RigidSelectiveTests[Eval].selective[Int, Int, Int])
 }

--- a/tests/src/test/scala/cats/tests/EvalSuite.scala
+++ b/tests/src/test/scala/cats/tests/EvalSuite.scala
@@ -14,5 +14,5 @@ class EvalSuite extends CatsSuite {
   implicit val selective = Selective.fromMonad[Eval]
 
   checkAll("Eval[Int]", SelectiveTests[Eval].selective[Int, Int, Int])
-  checkAll("Eval[Int]", RigidSelectiveTests[Eval].selective[Int, Int, Int])
+  checkAll("Eval[Int]", RigidSelectiveTests[Eval].selective[Int, Int])
 }

--- a/tests/src/test/scala/cats/tests/SelectiveSuite.scala
+++ b/tests/src/test/scala/cats/tests/SelectiveSuite.scala
@@ -121,4 +121,16 @@ class SelectiveSuite extends CatsSuite {
       }
     }
   }
+
+  test("apS") {
+    forAll { (fn: Option[Int => String], fa: Option[Int]) =>
+      fn match {
+        case None =>
+          testInstance.apS(fn)(fa) should ===(None)
+        case Some(f) =>
+          testInstance.apS(fn)(fa) should ===(fa.map(f))
+      }
+    }
+  }
+
 }

--- a/tests/src/test/scala/cats/tests/ValidatedSuite.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedSuite.scala
@@ -14,5 +14,5 @@ class ValidatedSuite extends CatsSuite {
 
   // This fails, as expected, because Validated[E,?] is no a *rigid* selective functor
   // Useful for checking that the rigid laws fail when they are expected to!
-  // checkAll("Validated[String, Int]", RigidSelectiveTests[Validated[String, ?]].selective[Int, Int, Int])
+  // checkAll("Validated[String, Int]", RigidSelectiveTests[Validated[String, ?]].selective[Int, Int])
 }

--- a/tests/src/test/scala/cats/tests/ValidatedSuite.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedSuite.scala
@@ -12,4 +12,7 @@ class ValidatedSuite extends CatsSuite {
 
   checkAll("Validated[String, Int]", SelectiveTests[Validated[String, ?]].selective[Int, Int, Int])
 
+  // This fails, as expected, because Validated[E,?] is no a *rigid* selective functor
+  // Useful for checking that the rigid laws fail when they are expected to!
+  // checkAll("Validated[String, Int]", RigidSelectiveTests[Validated[String, ?]].selective[Int, Int, Int])
 }


### PR DESCRIPTION
Hi!

I implemented the `apS` function from the paper.  I wasn't sure if it was deliberately omitted or not?  Maybe because you had in mind modelling rigid and non-rigid _Selectives_ separately, or perhaps there was some other reason?

If you think this might be a useful contribution, let me know and I'll expand on the testing a little further before submitting something for review.  But if not, don't feel obliged: I'm just satisfying my own curiosities!